### PR TITLE
Initialize reports collection on sign up

### DIFF
--- a/app/src/main/java/com/teduniversity/medicalai/ui/screens/SignUpScreen.kt
+++ b/app/src/main/java/com/teduniversity/medicalai/ui/screens/SignUpScreen.kt
@@ -196,14 +196,30 @@ fun SignUpScreen(
                                             .document(uid)
                                             .set(userData)
                                             .addOnSuccessListener {
-                                                loading = false
-                                                // Kayıt başarılı, toast göster ve yönlendir
-                                                Toast.makeText(
-                                                    context,
-                                                    "Registration successful!",
-                                                    Toast.LENGTH_SHORT
-                                                ).show()
-                                                onSignedUp()
+                                                // Kullanıcı belgesi oluşturulduktan sonra raporlar alt koleksiyonunu oluştur
+                                                val placeholder = hashMapOf(
+                                                    "welcome" to true,
+                                                    "createdAt" to com.google.firebase.Timestamp.now()
+                                                )
+                                                firestore.collection("patients")
+                                                    .document(uid)
+                                                    .collection("reports")
+                                                    .document("welcome")
+                                                    .set(placeholder)
+                                                    .addOnSuccessListener {
+                                                        loading = false
+                                                        // Kayıt başarılı, toast göster ve yönlendir
+                                                        Toast.makeText(
+                                                            context,
+                                                            "Registration successful!",
+                                                            Toast.LENGTH_SHORT
+                                                        ).show()
+                                                        onSignedUp()
+                                                    }
+                                                    .addOnFailureListener { e ->
+                                                        loading = false
+                                                        error = e.message
+                                                    }
                                             }
                                             .addOnFailureListener { e ->
                                                 loading = false


### PR DESCRIPTION
## Summary
- add creation of `reports` subcollection with a placeholder doc after signing up

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68408fbcc66c8331b8b014e8b9919fc2